### PR TITLE
net/ionic: ignore missing field initializers warning

### DIFF
--- a/drivers/net/ionic/Makefile
+++ b/drivers/net/ionic/Makefile
@@ -31,4 +31,7 @@ SRCS-$(CONFIG_RTE_LIBRTE_IONIC_PMD) += ionic_ethdev.c
 SRCS-$(CONFIG_RTE_LIBRTE_IONIC_PMD) += ionic_lif.c
 SRCS-$(CONFIG_RTE_LIBRTE_IONIC_PMD) += ionic_main.c
 
+CFLAGS_ionic_dev.o += -Wno-missing-field-initializers
+CFLAGS_ionic_lif.o += -Wno-missing-field-initializers
+
 include $(RTE_SDK)/mk/rte.lib.mk

--- a/drivers/net/ionic/meson.build
+++ b/drivers/net/ionic/meson.build
@@ -11,3 +11,12 @@ sources = files(
 	'ionic_main.c'
 )
 
+error_cflags = [
+  '-Wno-missing-field-initializers',
+]
+
+foreach flag: error_cflags
+        if cc.has_argument(flag)
+                c_args += flag
+        endif
+endforeach


### PR DESCRIPTION
The compiler warning is:
   from .../drivers/net/ionic/ionic_dev.c:7:
.../drivers/net/ionic/ionic_if.h:202:5: note: ‘rsvd’ declared here
  u8 rsvd[62];
     ^

This has been observed with gcc 4.8.5, newer 9+ compiler are not giving
this warning.

Warning is a reminder to the user that there are some fields in the
struct not initialized with the default value.
But the C standard clarifies that in that case the field value will be
zero and code is aware of this behavior, so no initializing to a default
value is intentional and it is safe to ignore this compiler warning.

Adding '-Wno-missing-field-initializers' compiler flag to disable the
warning.

Reported-by: Anoob Joseph <anoobj@marvell.com>
Reported-by: Raslan Darawsheh <rasland@mellanox.com>
Reported-by: Xueming Zhang <xuemingx.zhang@intel.com>
Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>