### PR TITLE
drivers: add crypto as dependency for event drivers

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -21,7 +21,7 @@ DEPDIRS-compress := bus mempool
 DIRS-$(CONFIG_RTE_LIBRTE_VHOST) += vdpa
 DEPDIRS-vdpa := common bus mempool
 DIRS-$(CONFIG_RTE_LIBRTE_EVENTDEV) += event
-DEPDIRS-event := common bus mempool net
+DEPDIRS-event := common bus mempool net crypto
 DIRS-$(CONFIG_RTE_LIBRTE_RAWDEV) += raw
 DEPDIRS-raw := common bus mempool net event
 


### PR DESCRIPTION
Since the introduction of crypto event adapters, event drivers
have dependencies on crypto drivers.

/usr/bin/ld: cannot find -lrte_pmd_dpaa_sec
collect2: error: ld returned 1 exit status
make[9]: *** [.../mk/rte.lib.mk:100:
	librte_pmd_dpaa_event.so.20.0.2] Error 1

Fixes: b0f66a68ca74 ("event/dpaa: support crypto adapter")
Fixes: 3721c39f405a ("event/dpaa2: support crypto adapter")
Cc: stable@dpdk.org

Reported-by: David Marchand <david.marchand@redhat.com>
Suggested-by: Ferruh Yigit <ferruh.yigit@intel.com>
Signed-off-by: Hemant Agrawal <hemant.agrawal@nxp.com>
Acked-by: David Marchand <david.marchand@redhat.com>