### PR TITLE
usertools: read PCI device name as UTF-8

### DIFF
--- a/usertools/dpdk-devbind.py
+++ b/usertools/dpdk-devbind.py
@@ -213,7 +213,7 @@ def get_pci_device_details(dev_id, probe_lspci):
         for line in extra_info:
             if len(line) == 0:
                 continue
-            name, value = line.decode().split("\t", 1)
+            name, value = line.decode("utf8").split("\t", 1)
             name = name.strip(":") + "_str"
             device[name] = value
     # check for a unix interface name
@@ -259,7 +259,7 @@ def get_device_details(devices_type):
             # Clear previous device's data
             dev = {}
         else:
-            name, value = dev_line.decode().split("\t", 1)
+            name, value = dev_line.decode("utf8").split("\t", 1)
             value_list = value.rsplit(' ', 1)
             if len(value_list) > 1:
                 # String stored in <name>_str


### PR DESCRIPTION
Fixes the case where a PCI device string identifier
contains non-ASCII UTF-8

A particular example is Mellanox Connext-X 5 EN MT27800:

28:00.0 Ethernet controller: Mellanox Technologies
MT27800 Family [ConnectX-5]

Subsystem: Mellanox Technologies ConnectX®-5 EN network
interface card, 100GbE single-port QSFP28, PCIe3.0 x16,
tall bracket; MCX515A-CCAT

Signed-off-by: Christos Ricudis <ricudis@niometrics.com>
Acked-by: Andrew Rybchenko <arybchenko@solarflare.com>